### PR TITLE
doc: document the sign of the current field

### DIFF
--- a/src/DCSourceStatus.hpp
+++ b/src/DCSourceStatus.hpp
@@ -6,11 +6,23 @@
 
 namespace power_base
 {
+    /** Electrical status of a DC source/sink */
     struct DCSourceStatus
     {
         base::Time time;
+
+        /** Source voltage */
         float voltage = base::unknown<float>();
+
+        /** Current in A
+         *
+         * Positive if acting as a source, negative as a sink (e.g. recharging a
+         * battery)
+         */
         float current = base::unknown<float>();
+
+        /** Maximum current this source can provide (in A)
+         */
         float max_current = base::unknown<float>();
     };
 


### PR DESCRIPTION
Batteries can have positive (discharge) or negative (charge) current.
Document it properly